### PR TITLE
Fix mobile viewport issues and input background

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -289,7 +289,7 @@ button[disabled] {
     padding-right: 12px;
     padding-bottom: calc(12px + env(safe-area-inset-bottom));
     box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), #fff);
+    background: transparent;
   }
   textarea {
     min-height: 48px;

--- a/client/global.css
+++ b/client/global.css
@@ -289,6 +289,7 @@ button[disabled] {
   .chat-input {
     padding-left: 12px;
     padding-right: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom));
     box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), #fff);
   }

--- a/client/global.css
+++ b/client/global.css
@@ -272,9 +272,7 @@ button[disabled] {
     touch-action: pan-y;
   }
   .chat-wrap {
-    height: calc(
-      100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom)
-    );
+    height: 100dvh;
     min-height: 100dvh;
     overflow: hidden;
     display: flex;

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -325,8 +325,8 @@ export default function Index() {
   }
 
   return (
-    <div className="h-screen bg-slate-50 p-0 md:p-0 md:overflow-hidden">
-      <div className="w-full h-full flex gap-0 items-stretch">
+    <div className="min-h-[100dvh] bg-slate-50 p-0 md:p-0 md:overflow-hidden">
+      <div className="w-full h-full min-h-0 flex gap-0 items-stretch">
         {/* Sidebar - visible on md+ */}
         <aside className="hidden md:flex flex-col w-64 bg-slate-100 text-slate-700 py-4 px-4 h-full sticky top-0 overflow-y-auto items-start border-r border-slate-100">
           <div className="flex items-center w-full mt-0">
@@ -445,8 +445,8 @@ export default function Index() {
         )}
 
         {/* Main chat area */}
-        <main className="flex-1 flex">
-          <div className="chat-wrap w-full h-full flex flex-col bg-transparent">
+        <main className="flex-1 flex min-h-0">
+          <div className="chat-wrap w-full h-full min-h-0 flex flex-col bg-transparent">
             <header className="flex items-center gap-3 px-4 py-3 border-b border-slate-100 bg-transparent">
               <button
                 type="button"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -22,11 +22,19 @@ export default function Index() {
   const uploadRef = useRef<HTMLInputElement | null>(null);
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  const isMobileRef = useRef(false);
+
+  useEffect(() => {
+    // detect mobile once on mount
+    if (typeof window !== "undefined") {
+      isMobileRef.current = window.matchMedia("(max-width: 767px)").matches;
+    }
+  }, []);
 
   useEffect(() => {
     scrollToBottom();
-    // autofocus input when not waiting
-    if (!waiting) inputRef.current?.focus?.();
+    // avoid auto-focus on mobile to prevent viewport jump
+    if (!waiting && !isMobileRef.current) inputRef.current?.focus?.();
   }, [messages, waiting]);
 
   function scrollToBottom() {


### PR DESCRIPTION
## Purpose

Fix mobile viewport issues where the screen unexpectedly scrolls up creating unwanted space below the chat input area, and ensure the input container background matches the desktop version (transparent instead of white gradient).

## Code changes

- **CSS Layout**: Simplified chat-wrap height calculation by removing safe-area-inset adjustments and using `100dvh` directly
- **Input Styling**: Changed chat-input background from white gradient to transparent and added bottom padding with safe-area-inset for proper spacing
- **Mobile Detection**: Added mobile device detection to prevent auto-focus on mobile devices that causes viewport jumping
- **Container Heights**: Updated main container and chat-wrap to use `min-h-0` for proper flex behavior and prevent overflow issues

These changes ensure consistent mobile experience without unexpected scrolling and maintain visual consistency across desktop and mobile platforms.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/84c388840b5c467d922a066827028a64/spark-oasis)

👀 [Preview Link](https://84c388840b5c467d922a066827028a64-spark-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>84c388840b5c467d922a066827028a64</projectId>-->
<!--<branchName>spark-oasis</branchName>-->