### PR TITLE
Update header with assistant selector and improve input styling

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -197,19 +197,19 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.22);
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* compact, denser shadow (darker but not wider) */
-  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.18);
+  /* denser, darker compact shadow (not wide) */
+  box-shadow: 0 6px 8px rgba(15, 23, 42, 0.32);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 7px 12px rgba(15, 23, 42, 0.20);
+  box-shadow: 0 7px 10px rgba(15, 23, 42, 0.34);
   transform: translateY(-1px);
 }
 
@@ -217,9 +217,9 @@ input[type="text"]:focus,
 input[type="search"]:focus,
 input:focus,
 textarea:focus {
-  border-color: rgba(15, 23, 42, 0.20);
-  /* keep same compact shadow but slightly darker */
-  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.20);
+  border-color: rgba(15, 23, 42, 0.26);
+  /* keep compact dark shadow */
+  box-shadow: 0 6px 8px rgba(15, 23, 42, 0.36);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -197,19 +197,19 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.18);
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* compact, non-widening shadow that still feels raised */
-  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.06);
+  /* compact, denser shadow (darker but not wider) */
+  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.18);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 7px 12px rgba(15, 23, 42, 0.07);
+  box-shadow: 0 7px 12px rgba(15, 23, 42, 0.20);
   transform: translateY(-1px);
 }
 
@@ -217,9 +217,9 @@ input[type="text"]:focus,
 input[type="search"]:focus,
 input:focus,
 textarea:focus {
-  border-color: rgba(15, 23, 42, 0.16);
-  /* match default shadow so appearance stays consistent */
-  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.06);
+  border-color: rgba(15, 23, 42, 0.20);
+  /* keep same compact shadow but slightly darker */
+  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.20);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -201,15 +201,15 @@ textarea {
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* denser, darker compact shadow (not wide) */
-  box-shadow: 0 6px 8px rgba(15, 23, 42, 0.32);
+  /* compact, very dense shadow (small blur, darker) */
+  box-shadow: 0 3px 6px rgba(15, 23, 42, 0.48);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 7px 10px rgba(15, 23, 42, 0.34);
+  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.52);
   transform: translateY(-1px);
 }
 
@@ -217,9 +217,9 @@ input[type="text"]:focus,
 input[type="search"]:focus,
 input:focus,
 textarea:focus {
-  border-color: rgba(15, 23, 42, 0.26);
-  /* keep compact dark shadow */
-  box-shadow: 0 6px 8px rgba(15, 23, 42, 0.36);
+  border-color: rgba(15, 23, 42, 0.28);
+  /* keep compact dense shadow on focus */
+  box-shadow: 0 3px 6px rgba(15, 23, 42, 0.56);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -197,10 +197,20 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.10);
   background: #fff;
-  transition: box-shadow 0.12s ease, border-color 0.12s ease;
+  transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
+  /* subtle raised appearance by default */
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.03);
+}
+
+input[type="text"]:hover,
+input[type="search"]:hover,
+input:hover,
+textarea:hover {
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.04);
+  transform: translateY(-1px);
 }
 
 input[type="text"]:focus,
@@ -208,7 +218,8 @@ input[type="search"]:focus,
 input:focus,
 textarea:focus {
   border-color: rgba(15, 23, 42, 0.16);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  transform: translateY(-1px);
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -201,15 +201,15 @@ textarea {
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* shadow reduced by ~60%: smaller blur + lower alpha, remains compact */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.19);
+  /* shadow reduced by ~60% earlier; now reduce darkness by 40% (lower alpha) */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.11);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.21);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.13);
   transform: translateY(-1px);
 }
 
@@ -218,8 +218,8 @@ input[type="search"]:focus,
 input:focus,
 textarea:focus {
   border-color: rgba(15, 23, 42, 0.28);
-  /* compact, slightly stronger on focus but still reduced */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.22);
+  /* compact, slightly stronger on focus but reduced darkness */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.13);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -234,14 +234,15 @@ textarea:focus {
   --tw-ring-color: transparent !important;
 }
 
-/* remove pink highlight on focus/click; keep subtle bubble-style focus */
+/* show thin pink ring on focus */
 .chat-input textarea:focus,
 .chat-input input[type="text"]:focus,
 .chat-input textarea:focus-visible,
 .chat-input input[type="text"]:focus-visible {
-  border-color: rgba(15, 23, 42, 0.08) !important; /* match bubble border */
+  border-color: rgba(190,24,93,0.28) !important; /* subtle pink border */
   outline: none !important;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
+  /* base subtle shadow + thin pink ring */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important, 0 0 0 3px rgba(190,24,93,0.08) !important;
 }
 
 /* active state matches focus (no pink) */

--- a/client/global.css
+++ b/client/global.css
@@ -239,17 +239,16 @@ textarea:focus {
 .chat-input input[type="text"]:focus,
 .chat-input textarea:focus-visible,
 .chat-input input[type="text"]:focus-visible {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
   border-color: rgba(190,24,93,0.28) !important; /* slightly pink border */
   outline: none !important;
-  /* subtle pink glow */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) , 0 0 0 6px rgba(190,24,93,0.06) !important;
+  /* single combined shadow: subtle base shadow + pink glow */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 0 0 6px rgba(190,24,93,0.06) !important;
 }
 
 /* also add an active inner ring for stronger feedback while typing */
 .chat-input textarea:active,
 .chat-input input[type="text"]:active {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) , 0 0 0 8px rgba(190,24,93,0.08) !important;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 0 0 8px rgba(190,24,93,0.08) !important;
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -199,7 +199,10 @@ textarea {
   border-radius: 12px;
   border: 1px solid rgba(15, 23, 42, 0.22);
   background: #fff;
-  transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
+  transition:
+    box-shadow 0.12s ease,
+    border-color 0.12s ease,
+    transform 0.12s ease;
   outline: none;
   /* shadow reduced by ~60% earlier; now reduce darkness by 40% (lower alpha) */
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.11);
@@ -239,10 +242,12 @@ textarea:focus {
 .chat-input input[type="text"]:focus,
 .chat-input textarea:focus-visible,
 .chat-input input[type="text"]:focus-visible {
-  border-color: rgba(190,24,93,0.28) !important; /* subtle pink border */
+  border-color: rgba(190, 24, 93, 0.28) !important; /* subtle pink border */
   outline: none !important;
   /* base subtle shadow + thin pink ring */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important, 0 0 0 3px rgba(190,24,93,0.08) !important;
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.06) !important,
+    0 0 0 3px rgba(190, 24, 93, 0.08) !important;
 }
 
 /* active state matches focus (no pink) */

--- a/client/global.css
+++ b/client/global.css
@@ -228,14 +228,27 @@ textarea:focus {
 .chat-input input[type="text"] {
   background: #fff; /* same as agent bubble */
   border: 1px solid rgba(15, 23, 42, 0.06); /* lighter border like message bubble */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); /* compact, subtle shadow matching bubble */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important; /* compact, subtle shadow matching bubble */
   transform: none !important; /* prevent lift */
+  outline: none !important;
+  --tw-ring-color: transparent !important;
 }
 
 .chat-input textarea:focus,
 .chat-input input[type="text"]:focus {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
-  border-color: rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
+  border-color: rgba(15, 23, 42, 0.08) !important;
+  outline: none !important;
+  --tw-ring-color: transparent !important;
+}
+
+/* Also disable focus-visible ring utility if present */
+.chat-input textarea:focus-visible,
+.chat-input input[type="text"]:focus-visible {
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
+  border-color: rgba(15, 23, 42, 0.08) !important;
+  outline: none !important;
+  --tw-ring-color: transparent !important;
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -222,6 +222,21 @@ textarea:focus {
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.13);
   transform: translateY(-1px);
 }
+
+/* Make chat input match agent message bubble */
+.chat-input textarea,
+.chat-input input[type="text"] {
+  background: #fff; /* same as agent bubble */
+  border: 1px solid rgba(15, 23, 42, 0.06); /* lighter border like message bubble */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); /* compact, subtle shadow matching bubble */
+  transform: none !important; /* prevent lift */
+}
+
+.chat-input textarea:focus,
+.chat-input input[type="text"]:focus {
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+  border-color: rgba(15, 23, 42, 0.08);
+}
 button {
   font-weight: 600;
   border-radius: 10px;

--- a/client/global.css
+++ b/client/global.css
@@ -234,21 +234,22 @@ textarea:focus {
   --tw-ring-color: transparent !important;
 }
 
+/* show pink highlight when typing (focused) */
 .chat-input textarea:focus,
-.chat-input input[type="text"]:focus {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
-  border-color: rgba(15, 23, 42, 0.08) !important;
-  outline: none !important;
-  --tw-ring-color: transparent !important;
-}
-
-/* Also disable focus-visible ring utility if present */
+.chat-input input[type="text"]:focus,
 .chat-input textarea:focus-visible,
 .chat-input input[type="text"]:focus-visible {
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
-  border-color: rgba(15, 23, 42, 0.08) !important;
+  border-color: rgba(190,24,93,0.28) !important; /* slightly pink border */
   outline: none !important;
-  --tw-ring-color: transparent !important;
+  /* subtle pink glow */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) , 0 0 0 6px rgba(190,24,93,0.06) !important;
+}
+
+/* also add an active inner ring for stronger feedback while typing */
+.chat-input textarea:active,
+.chat-input input[type="text"]:active {
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) , 0 0 0 8px rgba(190,24,93,0.08) !important;
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -185,7 +185,7 @@ html {
   display: flex;
   gap: 12px;
   padding: 12px 16px;
-  border-top: 1px solid rgba(15, 23, 42, 0.03);
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
   background: transparent;
   flex: none;
 }
@@ -197,8 +197,18 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border: 1px solid rgba(15, 23, 42, 0.12);
   background: #fff;
+  transition: box-shadow 0.12s ease, border-color 0.12s ease;
+  outline: none;
+}
+
+input[type="text"]:focus,
+input[type="search"]:focus,
+input:focus,
+textarea:focus {
+  border-color: rgba(15, 23, 42, 0.16);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -234,21 +234,20 @@ textarea:focus {
   --tw-ring-color: transparent !important;
 }
 
-/* show pink highlight when typing (focused) */
+/* remove pink highlight on focus/click; keep subtle bubble-style focus */
 .chat-input textarea:focus,
 .chat-input input[type="text"]:focus,
 .chat-input textarea:focus-visible,
 .chat-input input[type="text"]:focus-visible {
-  border-color: rgba(190,24,93,0.28) !important; /* slightly pink border */
+  border-color: rgba(15, 23, 42, 0.08) !important; /* match bubble border */
   outline: none !important;
-  /* single combined shadow: subtle base shadow + pink glow */
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 0 0 6px rgba(190,24,93,0.06) !important;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
 }
 
-/* also add an active inner ring for stronger feedback while typing */
+/* active state matches focus (no pink) */
 .chat-input textarea:active,
 .chat-input input[type="text"]:active {
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 0 0 8px rgba(190,24,93,0.08) !important;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
 }
 button {
   font-weight: 600;

--- a/client/global.css
+++ b/client/global.css
@@ -197,19 +197,19 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.16);
+  border: 1px solid rgba(15, 23, 42, 0.12);
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* stronger raised appearance by default (match focus) */
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  /* compact, non-widening shadow that still feels raised */
+  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.06);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 7px 12px rgba(15, 23, 42, 0.07);
   transform: translateY(-1px);
 }
 
@@ -218,7 +218,8 @@ input[type="search"]:focus,
 input:focus,
 textarea:focus {
   border-color: rgba(15, 23, 42, 0.16);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  /* match default shadow so appearance stays consistent */
+  box-shadow: 0 6px 10px rgba(15, 23, 42, 0.06);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -201,15 +201,15 @@ textarea {
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* compact, very dense shadow (small blur, darker) */
-  box-shadow: 0 3px 6px rgba(15, 23, 42, 0.48);
+  /* shadow reduced by ~60%: smaller blur + lower alpha, remains compact */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.19);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.52);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.21);
   transform: translateY(-1px);
 }
 
@@ -218,8 +218,8 @@ input[type="search"]:focus,
 input:focus,
 textarea:focus {
   border-color: rgba(15, 23, 42, 0.28);
-  /* keep compact dense shadow on focus */
-  box-shadow: 0 3px 6px rgba(15, 23, 42, 0.56);
+  /* compact, slightly stronger on focus but still reduced */
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.22);
   transform: translateY(-1px);
 }
 button {

--- a/client/global.css
+++ b/client/global.css
@@ -197,19 +197,19 @@ textarea {
   font-size: 1rem;
   padding: 10px 12px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.10);
+  border: 1px solid rgba(15, 23, 42, 0.16);
   background: #fff;
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
   outline: none;
-  /* subtle raised appearance by default */
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.03);
+  /* stronger raised appearance by default (match focus) */
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
 input[type="text"]:hover,
 input[type="search"]:hover,
 input:hover,
 textarea:hover {
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
   transform: translateY(-1px);
 }
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -23,10 +23,10 @@ export default function Index() {
 
   // Assistant selection / popover
   const [assistantMenuOpen, setAssistantMenuOpen] = useState(false);
-  const [selectedAssistant, setSelectedAssistant] = useState<string>("IP Assistant v");
+  const [selectedAssistant, setSelectedAssistant] = useState<string>("IP Assistant");
   const assistantMenuRef = useRef<HTMLDivElement | null>(null);
   const assistantOptions = [
-    { id: "ip", label: "IP Assistant v" },
+    { id: "ip", label: "IP Assistant" },
     { id: "defi", label: "DeFi Assistant (Soon)", soon: true },
     { id: "nft", label: "NFT (Soon)", soon: true },
   ];

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -20,10 +20,34 @@ export default function Index() {
   const [input, setInput] = useState("");
   const [waiting, setWaiting] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Assistant selection / popover
+  const [assistantMenuOpen, setAssistantMenuOpen] = useState(false);
+  const [selectedAssistant, setSelectedAssistant] = useState<string>("IP Assistant v");
+  const assistantMenuRef = useRef<HTMLDivElement | null>(null);
+  const assistantOptions = [
+    { id: "ip", label: "IP Assistant v" },
+    { id: "defi", label: "DeFi Assistant (Soon)", soon: true },
+    { id: "nft", label: "NFT (Soon)", soon: true },
+  ];
+
   const uploadRef = useRef<HTMLInputElement | null>(null);
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
   const isMobileRef = useRef(false);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (
+        assistantMenuRef.current &&
+        !assistantMenuRef.current.contains(e.target as Node)
+      ) {
+        setAssistantMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, []);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -488,9 +512,50 @@ export default function Index() {
                 alt="Radut Agent"
                 className="w-10 h-10 rounded-full object-cover ring-2 ring-slate-100"
               />
-              <h1 className="text-lg font-semibold tracking-tight text-slate-900">
-                Radut Agent
-              </h1>
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setAssistantMenuOpen((s) => !s)}
+                  className="text-lg font-semibold tracking-tight text-slate-900 inline-flex items-center gap-2 focus:outline-none"
+                  aria-expanded={assistantMenuOpen}
+                >
+                  {selectedAssistant}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-4 h-4 text-slate-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+
+                {assistantMenuOpen && (
+                  <div
+                    ref={assistantMenuRef}
+                    className="absolute left-0 mt-2 w-52 bg-white border border-slate-100 rounded-md shadow-sm z-50"
+                  >
+                    <div className="py-2">
+                      {assistantOptions.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() => {
+                            setSelectedAssistant(opt.label);
+                            setAssistantMenuOpen(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-sm hover:bg-slate-50 transition-colors flex items-center justify-between"
+                        >
+                          <span>{opt.label}</span>
+                          {opt.soon ? (
+                            <span className="text-xs text-slate-400">Soon</span>
+                          ) : null}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
             </motion.header>
             <div className="chat-box px-4 md:px-12 py-6 flex-1 overflow-y-auto bg-transparent">
               <AnimatePresence initial={false}>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -23,7 +23,8 @@ export default function Index() {
 
   // Assistant selection / popover
   const [assistantMenuOpen, setAssistantMenuOpen] = useState(false);
-  const [selectedAssistant, setSelectedAssistant] = useState<string>("IP Assistant");
+  const [selectedAssistant, setSelectedAssistant] =
+    useState<string>("IP Assistant");
   const assistantMenuRef = useRef<HTMLDivElement | null>(null);
   const assistantOptions = [
     { id: "ip", label: "IP Assistant" },
@@ -527,7 +528,12 @@ export default function Index() {
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
                   </svg>
                 </button>
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements UI improvements to enhance the chat interface experience:
- Replace "Radut Agent" with a clickable assistant selector in the header
- Improve input field styling to match agent message bubbles
- Add subtle pink focus indicators for better user interaction feedback
- Remove unwanted visual artifacts like double pink layers and shadows

## Code changes

**Header updates:**
- Replaced static "Radut Agent" text with interactive dropdown showing "IP Assistant"
- Added assistant selection menu with options for IP Assistant, DeFi Assistant (Soon), and NFT (Soon)
- Implemented click-outside-to-close functionality for the dropdown

**Input styling improvements:**
- Updated chat input styling to match agent message bubble appearance
- Added subtle pink focus ring (3px with low opacity) when typing
- Removed unwanted shadow effects and double pink layers
- Enhanced border colors and transitions for better visual feedback
- Applied consistent styling across text inputs and textareas

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/84c388840b5c467d922a066827028a64/orbit-works)

👀 [Preview Link](https://84c388840b5c467d922a066827028a64-orbit-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>84c388840b5c467d922a066827028a64</projectId>-->
<!--<branchName>orbit-works</branchName>-->