### PR TITLE
Fix Vercel deployment issues with binary handling and imports

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -2,7 +2,9 @@ import serverless from "serverless-http";
 import { createServer } from "../server/index.js";
 
 const app = createServer();
-const handler = serverless(app);
+const handler = serverless(app, {
+  binary: ["image/*", "multipart/form-data", "application/octet-stream"],
+});
 
 export default async function (req: any, res: any) {
   return handler(req, res);

--- a/server/routes/analyze.ts
+++ b/server/routes/analyze.ts
@@ -1,7 +1,6 @@
 import multer from "multer";
 import { RequestHandler } from "express";
-
-const crypto = await import("crypto");
+import { createHash } from "crypto";
 
 const cache = new Map<string, any>();
 const upload = multer({
@@ -68,7 +67,7 @@ const analyzeHandler: RequestHandler = async (req, res) => {
     if (!file) return res.status(400).json({ error: "No file received" });
 
     // caching by hash
-    const hash = crypto.createHash("sha256").update(file.buffer).digest("hex");
+    const hash = createHash("sha256").update(file.buffer).digest("hex");
     if (cache.has(hash)) return res.status(200).json(cache.get(hash));
 
     // size guard


### PR DESCRIPTION
## Purpose
The user was experiencing issues where their AI analysis feature worked correctly in Builder.io preview but failed to load properly when deployed to Vercel. The bubble chat component would show a loading state indefinitely instead of displaying the AI analysis output.

## Code changes
- **Enhanced serverless configuration**: Added binary content type support for images, multipart form data, and octet streams in the serverless handler to properly handle file uploads in Vercel environment
- **Fixed crypto import**: Changed from dynamic `await import("crypto")` to direct named import `createHash` from crypto module to resolve module loading issues in serverless deployment

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/60332fa959464500bee653cf1b070bfd/glow-sanctuary)

👀 [Preview Link](https://60332fa959464500bee653cf1b070bfd-glow-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>60332fa959464500bee653cf1b070bfd</projectId>-->
<!--<branchName>glow-sanctuary</branchName>-->