### PR TITLE
Add 70% visibility requirement for face detection

### DIFF
--- a/server/routes/analyze.ts
+++ b/server/routes/analyze.ts
@@ -98,6 +98,7 @@ Rules:
 - Fill every field; use null only where schema allows.
 - "rationale", "evidence", "ai_artifacts", "human_cues", "overall_notes" are arrays of terse strings.
 - "count" must be an integer >=0 or null if unknown.
+- Only mark faces as present when at least 70% of key facial features (eyes, nose, mouth) are clearly visible; otherwise set presence="None" and count=0.
 - "primary_source" must reflect your best hypothesis given evidence.
 - If unsure about brands, set present=false and leave names empty.
 - If unsure about identities, use "Unknown" presence and empty arrays.


### PR DESCRIPTION
## Purpose
The user requested to improve face detection accuracy by implementing a stricter visibility threshold. They wanted faces to be considered present only when at least 70% of key facial features are clearly visible, rather than detecting partial or unclear faces.

## Code changes
- Added a new rule to the AI prompt requiring 70% visibility of key facial features (eyes, nose, mouth) for positive face detection
- Updated the detection logic to set `presence="None"` and `count=0` when faces don't meet the 70% visibility threshold
- This change ensures more accurate face detection by filtering out partially obscured or unclear faces

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/03aead6e18ee4c57866db7fc01a9ad2b/mystic-works)

👀 [Preview Link](https://03aead6e18ee4c57866db7fc01a9ad2b-mystic-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>03aead6e18ee4c57866db7fc01a9ad2b</projectId>-->
<!--<branchName>mystic-works</branchName>-->