### PR TITLE
Refine search bar styling in chat history

### DIFF
--- a/client/pages/History.tsx
+++ b/client/pages/History.tsx
@@ -199,7 +199,7 @@ const History = () => {
     <DashboardLayout title="Chat History">
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         <aside className="hidden w-80 flex-col border-r border-white/10 px-6 py-8 text-sm text-slate-300 md:flex">
-          <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-wide text-slate-300">
+          <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 py-[7px] pl-[11px] pr-0 text-xs uppercase tracking-wide text-slate-300">
             <span className="text-[10px] font-semibold text-[#FF4DA6]">
               Search
             </span>
@@ -208,7 +208,7 @@ const History = () => {
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Filter conversations"
-              className="flex-1 bg-transparent text-sm text-white placeholder:text-slate-400 focus:outline-none"
+              className="flex-1 bg-transparent text-[12px] text-white placeholder:text-slate-400 focus:outline-none"
             />
           </label>
           {renderSessionList()}
@@ -223,7 +223,7 @@ const History = () => {
 
         <section className="flex-1 min-h-0">
           <div className="md:hidden px-4 py-4">
-            <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-wide text-slate-300">
+            <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 py-[7px] pl-[11px] pr-0 text-xs uppercase tracking-wide text-slate-300">
               <span className="text-[10px] font-semibold text-[#FF4DA6]">
                 Search
               </span>
@@ -232,7 +232,7 @@ const History = () => {
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Filter conversations"
-                className="flex-1 bg-transparent text-sm text-white placeholder:text-slate-400 focus:outline-none"
+                className="flex-1 bg-transparent text-[12px] text-white placeholder:text-slate-400 focus:outline-none"
               />
             </label>
             <div className="mt-4 space-y-3">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
+      exifr:
+        specifier: ^7.1.3
+        version: 7.1.3
       express:
         specifier: ^5.1.0
         version: 5.1.0
@@ -22,7 +25,7 @@ importers:
         version: 1.4.5-lts.2
       openai:
         specifier: ^4.11.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       sharp:
         specifier: ^0.32.1
         version: 0.32.6
@@ -2849,6 +2852,9 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  exifr@7.1.3:
+    resolution: {integrity: sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -8530,6 +8536,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  exifr@7.1.3: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.2.2: {}
@@ -9194,7 +9202,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.129
       '@types/node-fetch': 2.6.13
@@ -9204,7 +9212,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
### Purpose

This pull request refines the styling of the search bar in the chat history page for a cleaner and more polished look.

### Code changes

- Adjusted padding and font size in the search bar component in `History.tsx`.
- Added the `exifr` package to the project dependencies.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 31`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0972413d840348bab00a0ed82fad3f09/cosmos-home)

👀 [Preview Link](https://0972413d840348bab00a0ed82fad3f09-cosmos-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0972413d840348bab00a0ed82fad3f09</projectId>-->
<!--<branchName>cosmos-home</branchName>-->