### PR TITLE
Feat: Automatically analyze uploaded images

### DIFF
--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -203,7 +203,7 @@ const getCurrentTimestamp = () =>
 
 const getInitialBotMessage = (): BotMessage => ({
   from: "bot",
-  text: "Hello, I am Radut Agent. Attach an image to analyze.",
+  text: "Hello, I am Radut Agent. Attach an image and I'll analyze it automatically.",
   ts: getCurrentTimestamp(),
 });
 

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -775,6 +775,8 @@ const IpAssistant = () => {
         autoScrollNextRef.current = true;
 
         // Compress and store the first image for later detection
+        let compressedBlob: Blob | null = null;
+        let fileName: string = "image.jpg";
         for (const f of files) {
           let blob: Blob;
           try {
@@ -785,14 +787,15 @@ const IpAssistant = () => {
           }
           lastUploadBlobRef.current = blob;
           lastUploadNameRef.current = f.name || "image.jpg";
+          compressedBlob = blob;
+          fileName = f.name || "image.jpg";
         }
 
-        // Show instruction message
-        pushMessage({
-          from: "bot",
-          text: "Image uploaded. Type 'register' to analyze it.",
-          ts: getCurrentTimestamp(),
-        });
+        // Automatically run detection on the uploaded image
+        if (compressedBlob) {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          await runDetection(compressedBlob, fileName);
+        }
       } catch (error: any) {
         console.error("handleImage error", error);
         const message = error?.message
@@ -806,7 +809,7 @@ const IpAssistant = () => {
         });
       }
     },
-    [compressAndEnsureSize, pushMessage],
+    [compressAndEnsureSize, pushMessage, runDetection],
   );
 
   const sidebarExtras = useCallback(


### PR DESCRIPTION
### Purpose

Based on the conversation, the user wants to streamline the image analysis workflow. The goal is to trigger the analysis automatically as soon as an image is uploaded, removing the need for the user to manually type a command to start the process.

### Code changes

- Modified the `handleImage` function to call `runDetection` immediately after an image is uploaded and processed.
- Removed the bot message that instructed the user to type 'register' after uploading.
- Updated the initial bot message to reflect that analysis now happens automatically upon upload.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9bcc02f9f27a441b8d1c79fec165af10/nova-oasis)

👀 [Preview Link](https://9bcc02f9f27a441b8d1c79fec165af10-nova-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9bcc02f9f27a441b8d1c79fec165af10</projectId>-->
<!--<branchName>nova-oasis</branchName>-->