### PR TITLE
Fix: Chat input focus and layout on mobile

### DIFF
--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -147,8 +147,8 @@ export const DashboardLayout = ({
           )}
         </AnimatePresence>
 
-        <main className="flex-1 flex min-h-0">
-          <div className="chat-wrap w-full h-full min-h-0 flex flex-col bg-gradient-to-b from-slate-950/50 via-slate-950/30 to-black">
+        <main className="flex-1 flex min-h-0 md:min-h-[100dvh]">
+          <div className="chat-wrap w-full md:h-full md:min-h-0 flex flex-col bg-gradient-to-b from-slate-950/50 via-slate-950/30 to-black">
             <motion.header
               className="flex items-center gap-4 px-6 py-4 border-b border-[#FF4DA6]/10 bg-gradient-to-r from-slate-950/60 via-[#FF4DA6]/5 to-slate-950/60 backdrop-blur-xl"
               variants={fadeUp}

--- a/client/global.css
+++ b/client/global.css
@@ -417,6 +417,8 @@ button.btn-ghost:focus-visible {
     height: 100%;
     overscroll-behavior: none; /* prevent scroll chaining */
     -webkit-overflow-scrolling: touch;
+    position: fixed;
+    width: 100%;
   }
   /* lock body scroll but allow chat-box to scroll */
   body {
@@ -429,19 +431,30 @@ button.btn-ghost:focus-visible {
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    width: 100%;
   }
-  /* avoid chat messages being hidden behind the sticky input */
+  /* avoid chat messages being hidden behind the fixed input */
   .chat-box {
-    padding-bottom: 64px;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+    min-height: 0;
   }
   .chat-input {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
     padding-left: 12px;
     padding-right: 12px;
     padding-bottom: calc(12px + env(safe-area-inset-bottom));
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
-    background: transparent;
+    width: 100%;
+    box-sizing: border-box;
+    z-index: 20;
+  }
+  .chat-input textarea,
+  .chat-input input {
+    position: relative;
+    z-index: 1;
   }
   textarea {
     min-height: 48px;

--- a/client/global.css
+++ b/client/global.css
@@ -417,8 +417,6 @@ button.btn-ghost:focus-visible {
     height: 100%;
     overscroll-behavior: none; /* prevent scroll chaining */
     -webkit-overflow-scrolling: touch;
-    position: fixed;
-    width: 100%;
   }
   /* lock body scroll but allow chat-box to scroll */
   body {
@@ -431,13 +429,13 @@ button.btn-ghost:focus-visible {
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    width: 100%;
   }
   /* avoid chat messages being hidden behind the fixed input */
   .chat-box {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     min-height: 0;
+    flex-shrink: 1;
   }
   .chat-input {
     position: fixed;
@@ -447,14 +445,8 @@ button.btn-ghost:focus-visible {
     padding-left: 12px;
     padding-right: 12px;
     padding-bottom: calc(12px + env(safe-area-inset-bottom));
-    width: 100%;
     box-sizing: border-box;
-    z-index: 20;
-  }
-  .chat-input textarea,
-  .chat-input input {
-    position: relative;
-    z-index: 1;
+    z-index: 50;
   }
   textarea {
     min-height: 48px;

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -1157,7 +1157,7 @@ const IpAssistant = () => {
       actions={headerActions}
       sidebarExtras={sidebarExtras}
     >
-      <div className="chat-box px-4 md:px-12 pt-4 pb-2 flex-1 overflow-y-auto bg-transparent">
+      <div className="chat-box px-4 md:px-12 pt-4 pb-[80px] md:pb-2 flex-1 overflow-y-auto bg-transparent">
         <AnimatePresence initial={false}>
           {messages.map((msg, index) => {
             if (msg.from === "user") {
@@ -1855,7 +1855,7 @@ const IpAssistant = () => {
       </div>
 
       <form
-        className="chat-input flex items-center gap-3.5 px-[1.45rem] py-3.5 border-t border-[#FF4DA6]/10 bg-gradient-to-r from-slate-950/60 via-[#FF4DA6]/5 to-slate-950/60 flex-none sticky bottom-0 z-10 backdrop-blur-xl transition-all duration-300"
+        className="chat-input flex items-center gap-3.5 px-[1.45rem] py-3.5 border-t border-[#FF4DA6]/10 bg-gradient-to-r from-slate-950/60 via-[#FF4DA6]/5 to-slate-950/60 flex-none md:sticky md:bottom-0 fixed bottom-0 left-0 right-0 md:static z-10 backdrop-blur-xl transition-all duration-300 md:z-10 w-full md:w-auto"
         onSubmit={(event) => {
           event.preventDefault();
           void handleSend();


### PR DESCRIPTION
### Purpose
This pull request addresses a bug reported by a user where the chat input on the mobile version would lose focus and scroll down during typing, creating a poor user experience. The goal is to stabilize the chat input's position and behavior on mobile devices.

### Code changes
- **`global.css`**: The `.chat-input` is now positioned `fixed` at the bottom of the viewport on mobile to keep it stationary.
- **`IpAssistant.tsx`**:
    - Added bottom padding to the `.chat-box` to prevent messages from being obscured by the fixed input.
    - The chat input form now uses `fixed` positioning for mobile and reverts to `sticky` for desktop views.
- **`DashboardLayout.tsx`**: Adjusted the main container's height and minimum height to ensure the layout works correctly with the fixed mobile input without breaking the desktop view.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9bcc02f9f27a441b8d1c79fec165af10/glow-zone)

👀 [Preview Link](https://9bcc02f9f27a441b8d1c79fec165af10-glow-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9bcc02f9f27a441b8d1c79fec165af10</projectId>-->
<!--<branchName>glow-zone</branchName>-->