### PR TITLE
feat: Remove external_url from metadata

### DIFF
--- a/client/hooks/useIPRegistrationAgent.ts
+++ b/client/hooks/useIPRegistrationAgent.ts
@@ -166,8 +166,6 @@ export function useIPRegistrationAgent() {
           mediaUrl: imageGateway,
           mediaHash: imageHash,
           mediaType: compressedFile.type || "image/jpeg",
-          external_url:
-            typeof window !== "undefined" ? window.location.origin : undefined,
           creators: creatorAddr
             ? [
                 {


### PR DESCRIPTION
### Purpose

Based on the conversation, the user requested the removal of the `external_url` from the IP registration metadata.

### Code changes

- Removed the `external_url` field from the metadata object in the `useIPRegistrationAgent` hook.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ec2bddc236a42efaa19291ac89c19aa/pulse-zone)

👀 [Preview Link](https://5ec2bddc236a42efaa19291ac89c19aa-pulse-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ec2bddc236a42efaa19291ac89c19aa</projectId>-->
<!--<branchName>pulse-zone</branchName>-->