### PR TITLE
Refactor: Update IP asset classification logic

### DIFF
--- a/server/routes/check-ip-assets.ts
+++ b/server/routes/check-ip-assets.ts
@@ -19,36 +19,30 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
     const { address } = req.body;
 
     if (!address || typeof address !== "string") {
-      return res
-        .status(400)
-        .json({
-          ok: false,
-          error: "address_required",
-          message: "Address is required",
-        });
+      return res.status(400).json({
+        ok: false,
+        error: "address_required",
+        message: "Address is required",
+      });
     }
 
     const trimmedAddress = address.trim();
     if (!/^0x[a-fA-F0-9]{40}$/.test(trimmedAddress)) {
-      return res
-        .status(400)
-        .json({
-          ok: false,
-          error: "invalid_address",
-          message: "Invalid Ethereum address format",
-        });
+      return res.status(400).json({
+        ok: false,
+        error: "invalid_address",
+        message: "Invalid Ethereum address format",
+      });
     }
 
     const apiKey = process.env.STORY_API_KEY;
     if (!apiKey) {
       console.error("STORY_API_KEY environment variable not configured");
-      return res
-        .status(500)
-        .json({
-          ok: false,
-          error: "server_config_missing",
-          message: "Server configuration error: STORY_API_KEY not set",
-        });
+      return res.status(500).json({
+        ok: false,
+        error: "server_config_missing",
+        message: "Server configuration error: STORY_API_KEY not set",
+      });
     }
 
     let allAssets: any[] = [];
@@ -107,14 +101,12 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
             }
 
             clearTimeout(timeoutId);
-            return res
-              .status(response.status)
-              .json({
-                ok: false,
-                error: `story_api_error`,
-                details: errorDetail,
-                status: response.status,
-              });
+            return res.status(response.status).json({
+              ok: false,
+              error: `story_api_error`,
+              details: errorDetail,
+              status: response.status,
+            });
           }
 
           const data = await response.json();
@@ -170,14 +162,12 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
               iteration: iterations,
             });
             clearTimeout(timeoutId);
-            return res
-              .status(504)
-              .json({
-                ok: false,
-                error: "timeout",
-                details:
-                  "The Story API is responding slowly. Please try again in a moment.",
-              });
+            return res.status(504).json({
+              ok: false,
+              error: "timeout",
+              details:
+                "The Story API is responding slowly. Please try again in a moment.",
+            });
           }
 
           console.error("Fetch request failed for Story API", {
@@ -188,13 +178,11 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
             errorType: fetchError?.name,
           });
           clearTimeout(timeoutId);
-          return res
-            .status(500)
-            .json({
-              ok: false,
-              error: "network_error",
-              details: fetchError?.message || "Unable to connect to Story API",
-            });
+          return res.status(500).json({
+            ok: false,
+            error: "network_error",
+            details: fetchError?.message || "Unable to connect to Story API",
+          });
         }
       }
 
@@ -232,15 +220,13 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
     }
   } catch (error: any) {
     console.error("Check IP Assets Error:", error);
-    res
-      .status(500)
-      .json({
-        ok: false,
-        error: error?.message || "Internal server error",
-        details:
-          process.env.NODE_ENV !== "production"
-            ? error?.stack
-            : "An unexpected error occurred",
-      });
+    res.status(500).json({
+      ok: false,
+      error: error?.message || "Internal server error",
+      details:
+        process.env.NODE_ENV !== "production"
+          ? error?.stack
+          : "An unexpected error occurred",
+    });
   }
 };

--- a/server/routes/check-ip-assets.ts
+++ b/server/routes/check-ip-assets.ts
@@ -208,13 +208,11 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
       }
 
       const originalCount = allAssets.filter((asset: any) => {
-        const parentCount = asset.parentsCount ?? 0;
-        return parentCount === 0;
+        return !asset.isDerivative;
       }).length;
 
       const remixCount = allAssets.filter((asset: any) => {
-        const parentCount = asset.parentsCount ?? 0;
-        return parentCount > 0;
+        return asset.isDerivative;
       }).length;
 
       const totalCount = allAssets.length;


### PR DESCRIPTION
### Purpose

The user wants to update the method for distinguishing between original and remix IP assets. The new logic, based on the user's provided code, uses the `isDerivative` boolean flag instead of checking the number of parents.

### Code changes

- Modified `server/routes/check-ip-assets.ts` to align with the new classification requirement.
- The logic for counting `originalCount` and `remixCount` now filters assets based on the `asset.isDerivative` flag.
- Replaced the previous implementation that checked `asset.parentsCount`.
- Applied minor code formatting improvements for consistency.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 62`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c072beea68ed4162b79a5031254660f4/mystic-space)

👀 [Preview Link](https://c072beea68ed4162b79a5031254660f4-mystic-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c072beea68ed4162b79a5031254660f4</projectId>-->
<!--<branchName>mystic-space</branchName>-->