### PR TITLE
feat: Make search result media expandable

### DIFF
--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2242,7 +2242,8 @@ const IpAssistant = () => {
                           <img
                             src={asset.mediaUrl}
                             alt={asset.title || "IP Asset"}
-                            className="w-full h-full object-cover"
+                            className="w-full h-full object-cover cursor-pointer"
+                            onClick={() => setExpandedAsset(asset)}
                             onError={(e) => {
                               const img = e.target as HTMLImageElement;
                               const parent = img.parentElement;

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2338,7 +2338,6 @@ const IpAssistant = () => {
                           </p>
                         )}
                       </div>
-
                     </div>
                   </div>
                 ))}

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2306,7 +2306,7 @@ const IpAssistant = () => {
                               : "bg-green-500/20 text-green-300"
                           }`}
                         >
-                          {asset.isDerivative ? "Derivative" : "Original"}
+                          {asset.isDerivative ? "Remix" : "Original"}
                         </span>
                         {asset.score !== undefined && (
                           <span className="text-xs px-2 py-1 bg-[#FF4DA6]/20 text-[#FF4DA6] rounded font-semibold whitespace-nowrap">

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2223,7 +2223,10 @@ const IpAssistant = () => {
                             </div>
                           </div>
                         ) : asset.mediaType?.startsWith("audio") ? (
-                          <div className="w-full h-full flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-purple-900 to-slate-900">
+                          <div
+                            className="w-full h-full flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-purple-900 to-slate-900 cursor-pointer"
+                            onClick={() => setExpandedAsset(asset)}
+                          >
                             <svg
                               className="w-12 h-12 text-purple-300"
                               fill="currentColor"

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2415,7 +2415,7 @@ const IpAssistant = () => {
             ) : (
               <img
                 src={expandedAsset.mediaUrl}
-                alt={expandedAsset.title}
+                alt={expandedAsset.title || expandedAsset.name || "IP Asset"}
                 className="w-full h-auto max-h-[70vh] object-contain"
               />
             )}

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2422,7 +2422,7 @@ const IpAssistant = () => {
 
             <div className="p-6 bg-slate-800/50 border-t border-slate-700">
               <h3 className="text-lg font-semibold text-slate-100 mb-2">
-                {expandedAsset.title || "Untitled"}
+                {expandedAsset.title || expandedAsset.name || "Untitled"}
               </h3>
               {expandedAsset.description && (
                 <p className="text-sm text-slate-300 mb-4">

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2295,7 +2295,7 @@ const IpAssistant = () => {
 
                     <div className="pt-3 space-y-2 flex flex-col flex-grow">
                       <h3 className="text-sm font-semibold text-slate-100 line-clamp-2 group-hover:text-[#FF4DA6] transition-colors">
-                        {asset.title || "Untitled"}
+                        {asset.title || asset.name || "Untitled"}
                       </h3>
 
                       <div className="flex items-center justify-between gap-2">

--- a/client/pages/IpAssistant.tsx
+++ b/client/pages/IpAssistant.tsx
@@ -2335,28 +2335,6 @@ const IpAssistant = () => {
                         )}
                       </div>
 
-                      <div className="flex flex-wrap gap-1.5 pt-3 mt-auto">
-                        <button
-                          type="button"
-                          className="text-xs px-2 py-1.5 rounded-md bg-[#FF4DA6]/20 text-[#FF4DA6] hover:bg-[#FF4DA6]/30 font-medium transition-all hover:scale-105"
-                        >
-                          License
-                        </button>
-                        <button
-                          type="button"
-                          disabled={!authenticated}
-                          className="text-xs px-2 py-1.5 rounded-md bg-blue-500/20 text-blue-300 hover:bg-blue-500/30 font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all hover:scale-105"
-                        >
-                          Buy
-                        </button>
-                        <button
-                          type="button"
-                          disabled={!authenticated}
-                          className="text-xs px-2 py-1.5 rounded-md bg-green-500/20 text-green-300 hover:bg-green-500/30 font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all hover:scale-105"
-                        >
-                          Remix
-                        </button>
-                      </div>
                     </div>
                   </div>
                 ))}
@@ -2448,7 +2426,7 @@ const IpAssistant = () => {
                   {expandedAsset.description}
                 </p>
               )}
-              <div className="flex flex-wrap gap-2 text-xs text-slate-400">
+              <div className="flex flex-wrap gap-2 text-xs text-slate-400 mb-4">
                 <span className="px-2 py-1 bg-slate-700 rounded">
                   {expandedAsset.mediaType
                     ?.replace("video/", "")
@@ -2467,6 +2445,28 @@ const IpAssistant = () => {
                     {(expandedAsset.score * 100).toFixed(0)}% Match
                   </span>
                 )}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  className="text-xs px-3 py-2 rounded-md bg-[#FF4DA6]/20 text-[#FF4DA6] hover:bg-[#FF4DA6]/30 font-medium transition-all hover:scale-105"
+                >
+                  License
+                </button>
+                <button
+                  type="button"
+                  disabled={!authenticated}
+                  className="text-xs px-3 py-2 rounded-md bg-blue-500/20 text-blue-300 hover:bg-blue-500/30 font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all hover:scale-105"
+                >
+                  Buy
+                </button>
+                <button
+                  type="button"
+                  disabled={!authenticated}
+                  className="text-xs px-3 py-2 rounded-md bg-green-500/20 text-green-300 hover:bg-green-500/30 font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all hover:scale-105"
+                >
+                  Remix
+                </button>
               </div>
             </div>
           </motion.div>

--- a/server/routes/check-ip-assets.ts
+++ b/server/routes/check-ip-assets.ts
@@ -196,11 +196,13 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
       }
 
       const originalCount = allAssets.filter((asset: any) => {
-        return !asset.isDerivative;
+        const parentIps = asset?.parentIps || [];
+        return parentIps.length === 0;
       }).length;
 
       const remixCount = allAssets.filter((asset: any) => {
-        return asset.isDerivative;
+        const parentIps = asset?.parentIps || [];
+        return parentIps.length > 0;
       }).length;
 
       const totalCount = allAssets.length;

--- a/server/routes/check-ip-assets.ts
+++ b/server/routes/check-ip-assets.ts
@@ -196,13 +196,13 @@ export const handleCheckIpAssets: any = async (req: any, res: any) => {
       }
 
       const originalCount = allAssets.filter((asset: any) => {
-        const parentIps = asset?.parentIps || [];
-        return parentIps.length === 0;
+        const parentsCount = asset?.parentsCount || 0;
+        return parentsCount === 0;
       }).length;
 
       const remixCount = allAssets.filter((asset: any) => {
-        const parentIps = asset?.parentIps || [];
-        return parentIps.length > 0;
+        const parentsCount = asset?.parentsCount || 0;
+        return parentsCount > 0;
       }).length;
 
       const totalCount = allAssets.length;

--- a/server/routes/search-by-owner.ts
+++ b/server/routes/search-by-owner.ts
@@ -427,7 +427,7 @@ export const handleSearchByOwner: RequestHandler = async (req, res) => {
             ownerAddress: result?.ownerAddress,
             lastUpdatedAt: result?.lastUpdatedAt,
             isDerivative: isDerivative,
-            parentIps: parentIps,
+            parentsCount: parentsCount,
           };
         }),
       );

--- a/server/routes/search-by-owner.ts
+++ b/server/routes/search-by-owner.ts
@@ -274,6 +274,10 @@ export const handleSearchByOwner: RequestHandler = async (req, res) => {
       // Enrich results with metadata
       let enrichedResults = await Promise.all(
         searchResults.map(async (result: any) => {
+          // Determine if asset is derivative by checking for parent IPs
+          const parentIps = result?.parentIps || [];
+          const isDerivative = parentIps.length > 0;
+
           const mediaType = result?.mediaType || "image";
 
           let mediaUrl = null;

--- a/server/routes/search-by-owner.ts
+++ b/server/routes/search-by-owner.ts
@@ -281,9 +281,9 @@ export const handleSearchByOwner: RequestHandler = async (req, res) => {
       // Enrich results with metadata
       let enrichedResults = await Promise.all(
         searchResults.map(async (result: any) => {
-          // Determine if asset is derivative by checking for parent IPs
-          const parentIps = result?.parentIps || [];
-          const isDerivative = parentIps.length > 0;
+          // Determine if asset is derivative by checking parentsCount
+          const parentsCount = result?.parentsCount || 0;
+          const isDerivative = parentsCount > 0;
 
           const mediaType = result?.mediaType || "image";
 

--- a/server/routes/search-by-owner.ts
+++ b/server/routes/search-by-owner.ts
@@ -419,7 +419,8 @@ export const handleSearchByOwner: RequestHandler = async (req, res) => {
             ipaMetadataUri: result?.ipaMetadataUri,
             ownerAddress: result?.ownerAddress,
             lastUpdatedAt: result?.lastUpdatedAt,
-            isDerivative: result?.isDerivative || false,
+            isDerivative: isDerivative,
+            parentIps: parentIps,
           };
         }),
       );

--- a/server/routes/search-by-owner.ts
+++ b/server/routes/search-by-owner.ts
@@ -269,6 +269,13 @@ export const handleSearchByOwner: RequestHandler = async (req, res) => {
         iterations,
       });
 
+      if (allAssets.length > 0) {
+        console.log(
+          "[Search By Owner] First asset sample:",
+          JSON.stringify(allAssets[0], null, 2).substring(0, 1500),
+        );
+      }
+
       const searchResults = allAssets;
 
       // Enrich results with metadata

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -147,11 +147,19 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
 
       const data = await response.json();
 
+      console.log("[Search IP] Full search API response:", JSON.stringify(data, null, 2));
       console.log("[Search IP] Response data:", {
         totalResults: data?.total,
         resultsCount: data?.data?.length,
         hasMore: data?.pagination?.hasMore,
       });
+
+      if (data?.data && Array.isArray(data.data) && data.data.length > 0) {
+        console.log(
+          "[Search IP] First search result sample:",
+          JSON.stringify(data.data[0], null, 2),
+        );
+      }
 
       if (!data) {
         return res.json({

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -199,8 +199,17 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
               const metadataData = await metadataResponse.json();
               const metadataMap = new Map();
 
+              console.log(
+                "[Search IP] Full metadata API response:",
+                JSON.stringify(metadataData, null, 2).substring(0, 2000),
+              );
+
               if (Array.isArray(metadataData.data)) {
                 metadataData.data.forEach((asset: any) => {
+                  console.log(
+                    `[Search IP] Asset ${asset.ipId} full data:`,
+                    JSON.stringify(asset, null, 2).substring(0, 1000),
+                  );
                   metadataMap.set(asset.ipId, asset);
                 });
               }

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -399,8 +399,8 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
                     ipaMetadataUri: metadata?.ipaMetadataUri,
                     ownerAddress: metadata?.ownerAddress,
                     lastUpdatedAt: metadata?.lastUpdatedAt,
-                    isDerivative:
-                      metadata?.isDerivative || result.isDerivative || false,
+                    isDerivative: isDerivative,
+                    parentIps: parentIps,
                   };
                 }),
               );

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -417,7 +417,7 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
                     ownerAddress: metadata?.ownerAddress,
                     lastUpdatedAt: metadata?.lastUpdatedAt,
                     isDerivative: isDerivative,
-                    parentIps: parentIps,
+                    parentsCount: parentsCount,
                   };
                 }),
               );

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -209,11 +209,15 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
                 searchResults.map(async (result: any) => {
                   const metadata = metadataMap.get(result.ipId);
 
+                  // Determine if asset is derivative by checking for parent IPs
+                  const parentIps = metadata?.parentIps || [];
+                  const isDerivative = parentIps.length > 0;
+
                   console.log(
-                    `[Search IP] Asset ${result.ipId} - Search result isDerivative:`,
-                    result.isDerivative,
-                    ", Metadata isDerivative:",
-                    metadata?.isDerivative,
+                    `[Search IP] Asset ${result.ipId} - Parent IPs:`,
+                    parentIps,
+                    ", isDerivative:",
+                    isDerivative,
                   );
 
                   // Determine media type from result or metadata

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -147,7 +147,10 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
 
       const data = await response.json();
 
-      console.log("[Search IP] Full search API response:", JSON.stringify(data, null, 2));
+      console.log(
+        "[Search IP] Full search API response:",
+        JSON.stringify(data, null, 2),
+      );
       console.log("[Search IP] Response data:", {
         totalResults: data?.total,
         resultsCount: data?.data?.length,

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -226,13 +226,13 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
                 searchResults.map(async (result: any) => {
                   const metadata = metadataMap.get(result.ipId);
 
-                  // Determine if asset is derivative by checking for parent IPs
-                  const parentIps = metadata?.parentIps || [];
-                  const isDerivative = parentIps.length > 0;
+                  // Determine if asset is derivative by checking parentsCount
+                  const parentsCount = metadata?.parentsCount || 0;
+                  const isDerivative = parentsCount > 0;
 
                   console.log(
-                    `[Search IP] Asset ${result.ipId} - Parent IPs:`,
-                    parentIps,
+                    `[Search IP] Asset ${result.ipId} - parentsCount:`,
+                    parentsCount,
                     ", isDerivative:",
                     isDerivative,
                   );

--- a/server/routes/search-ip-assets.ts
+++ b/server/routes/search-ip-assets.ts
@@ -209,6 +209,13 @@ export const handleSearchIpAssets: RequestHandler = async (req, res) => {
                 searchResults.map(async (result: any) => {
                   const metadata = metadataMap.get(result.ipId);
 
+                  console.log(
+                    `[Search IP] Asset ${result.ipId} - Search result isDerivative:`,
+                    result.isDerivative,
+                    ", Metadata isDerivative:",
+                    metadata?.isDerivative,
+                  );
+
                   // Determine media type from result or metadata
                   const mediaType =
                     result?.mediaType || metadata?.mediaType || "image";


### PR DESCRIPTION
### Purpose
Based on the user's request, this change aims to enhance the media interaction on the search results page. The goal is to allow users to click on any media asset (image or audio) to open a larger, more detailed view. In this expanded view, users will find options to license, buy, or remix the asset.

### Code changes
- **Clickable Media:** Added `onClick` event handlers to image and audio elements in the search results. Clicking an asset now opens an expanded view.
- **UI Indication:** Applied the `cursor-pointer` class to media elements to show they are interactive.
- **Button Relocation:** Removed the "License", "Buy", and "Remix" buttons from the search result cards.
- **Expanded View Buttons:** Added the "License", "Buy", and "Remix" buttons to the expanded asset view.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 69`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1de93834d4494c409d59b16cb0dbd01c/vortex-space)

👀 [Preview Link](https://1de93834d4494c409d59b16cb0dbd01c-vortex-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1de93834d4494c409d59b16cb0dbd01c</projectId>-->
<!--<branchName>vortex-space</branchName>-->